### PR TITLE
Signal.schelp: small typo fix

### DIFF
--- a/HelpSource/Classes/Signal.schelp
+++ b/HelpSource/Classes/Signal.schelp
@@ -151,7 +151,7 @@ b = Signal.sineFill(512, [1]).play(true, 0.2);
 b.free;	// free the buffer again.
 ::
 argument::loop
-A link::Classes/Boolean:: whether to loop the entire signal or play it once. Default is to loop.
+A link::Classes/Boolean:: whether to loop the entire signal or play it once. Default is false.
 argument::mul
 volume at which to play it, 0.2 by default.
 argument::numChannels


### PR DESCRIPTION
Changed "default is to loop" to "default is false" under the play:loop argument description.